### PR TITLE
WIP: Introduce coding standards

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,22 @@
+# This file is for unifying the coding style for different editors and IDEs
+# editorconfig.org
+
+# PHP PSR-2 Coding Standards
+# http://www.php-fig.org/psr/psr-2/
+
+root = true
+
+; Unix-style newlines
+[*]
+end_of_line = LF
+
+[*.php]
+charset = utf-8
+end_of_line = lf
+insert_final_newline = true
+trim_trailing_whitespace = true
+indent_style = space
+indent_size = 4
+
+; top-most EditorConfig file
+root = true

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,12 @@
+language: php
+sudo: false
+php:
+  - 5.6
+  - 7.0
+  - 7.1
+before_install:
+  - composer self-update
+install:
+  - composer install
+script:
+  - ./vendor/bin/phpcs

--- a/composer.json
+++ b/composer.json
@@ -20,5 +20,8 @@
     },
     "require": {
         "guzzlehttp/guzzle": "^6.0"
-    }
+    },
+	"require-dev": {
+		"squizlabs/php_codesniffer": "2.*"
+	}
 }

--- a/composer.json
+++ b/composer.json
@@ -22,6 +22,7 @@
         "guzzlehttp/guzzle": "^6.0"
     },
 	"require-dev": {
-		"squizlabs/php_codesniffer": "2.*"
+		"squizlabs/php_codesniffer": "2.*",
+		"escapestudios/symfony2-coding-standard": "2.*"
 	}
 }

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0"?>
+<ruleset name="morning-train-toggl-api">
+  <description>The coding standard for Morningtrain Toggl API.</description>
+  <file>src</file>
+  <arg name="warning-severity" value="0"/>
+  <rule ref="PSR2"/>
+</ruleset>

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -3,5 +3,5 @@
   <description>The coding standard for Morningtrain Toggl API.</description>
   <file>src</file>
   <arg name="warning-severity" value="0"/>
-  <rule ref="PSR2"/>
+  <rule ref="vendor/escapestudios/symfony2-coding-standard/Symfony2"/>
 </ruleset>

--- a/src/TogglApi.php
+++ b/src/TogglApi.php
@@ -7,11 +7,11 @@ use GuzzleHttp\Exception\ClientException;
 
 class TogglApi
 {
-    
+
     protected $api_token = '';
-    
+
     protected $client;
-    
+
     public function __construct($api_token)
     {
         $this->api_token = $api_token;
@@ -20,7 +20,7 @@ class TogglApi
             'auth' => [$this->api_token, 'api_token']
         ]);
     }
-    
+
     private function GET($endpoint, $body = array(), $query = array())
     {
         try {
@@ -33,7 +33,7 @@ class TogglApi
             ];
         }
     }
-    
+
     private function POST($endpoint, $body = array(), $query = array())
     {
         try {
@@ -46,7 +46,7 @@ class TogglApi
             ];
         }
     }
-    
+
     private function PUT($endpoint, $body = array(), $query = array())
     {
         try {
@@ -59,7 +59,7 @@ class TogglApi
             ];
         }
     }
-    
+
     private function DELETE($endpoint, $body = array(), $query = array())
     {
         try {
@@ -72,7 +72,7 @@ class TogglApi
             ];
         }
     }
-    
+
     private function checkResponse($response)
     {
         if ($response->getStatusCode() == 200) {
@@ -84,14 +84,14 @@ class TogglApi
         }
         return false;
     }
-    
+
     public function getAvailableEndpoints()
     {
         return $this->get('');
     }
-    
+
     /* 	CLIENTS (https://github.com/toggl/toggl_api_docs/blob/master/chapters/clients.md)
-	
+
 		Client has the following properties
 
 		name: The name of the client (string, required, unique in workspace)
@@ -101,54 +101,54 @@ class TogglApi
 		cur: The name of the client's currency (string, not required, available only for pro workspaces)
 		at: timestamp that is sent in the response, indicates the time client was last updated
 	*/
-    
+
     public function createClient($client)
     {
         return $this->POST('clients', ['client' => $client]);
     }
-    
+
     public function updateClient($clientId, $client)
     {
         return $this->PUT('clients/'.$clientId, ['client' => $client]);
     }
-    
+
     public function deleteClient($clientId)
     {
         return $this->DELETE('clients/'.$clientId);
     }
-    
+
     public function getClients()
     {
         return $this->GET('clients');
     }
-    
+
     public function getClientProjects($clientId)
     {
         return $this->GET('clients/'.$clientId.'/projects');
     }
-    
+
     public function getActiveClientProjects($clientId)
     {
         return $this->GET('clients/'.$clientId.'/projects?active=true');
     }
-    
+
     public function getInactiveClientProjects($clientId)
     {
         return $this->GET('clients/'.$clientId.'/projects?active=false');
     }
-    
+
     public function getAllClientProjects($clientId)
     {
         return $this->GET('clients/'.$clientId.'/projects?active=both');
     }
-    
+
     public function getClientById($clientId)
     {
         return $this->GET('clients/'.$clientId);
     }
-    
+
     /* 	PROJECTS USERS (https://github.com/toggl/toggl_api_docs/blob/master/chapters/project_users.md)
-	
+
 		Project user has the following properties
 
 		pid: project ID (integer, required)
@@ -160,39 +160,39 @@ class TogglApi
 		Workspace id (wid), project id (pid) and user id (uid) can't be changed on update.
 
 	*/
-    
+
     public function createProjectUser($user)
     {
         return $this->POST('project_users', ['project_user' => $user]);
     }
-    
+
     public function createProjectUsers($user)
     {
         return $this->POST('project_users', ['project_user' => $user]);
     }
-    
+
     public function updateProjectUser($projectUserId, $user)
     {
         return $this->PUT('project_users/'.$projectUserId, ['project_user' => $user]);
     }
-    
+
     public function updateProjectUsers($projectUserIds, $user)
     {
         return $this->PUT('project_users/'.implode(',', $projectUserIds), ['project_user' => $user]);
     }
-    
+
     public function deleteProjectUser($projectUserId)
     {
         return $this->DELETE('project_users/'.$projectUserId);
     }
-    
+
     public function deleteProjectUsers($projectUserIds)
     {
         return $this->DELETE('project_users/'.implode(',', $projectUserIds));
     }
-    
+
     /* 	PROJECTS (https://github.com/toggl/toggl_api_docs/blob/master/chapters/projects.md)
-	
+
 		Project has the following properties
 
 		name: The name of the project (string, required, unique for client and workspace)
@@ -211,32 +211,32 @@ class TogglApi
 		created_at: timestamp indicating when the project was created (UTC time), read-only
 
 	*/
-    
+
     public function createProject($project)
     {
         return $this->POST('projects', ['project' => $project]);
     }
-    
+
     public function updateProject($projectId, $project)
     {
         return $this->PUT('projects/'.$projectId, ['project' => $project]);
     }
-    
+
     public function deleteProject($projectId)
     {
         return $this->DELETE('projects/'.$projectId);
     }
-    
+
     public function deleteProjects($projectIds)
     {
         return $this->DELETE('projects/'.implode(',', $projectIds));
     }
-    
+
     public function getProjectUserRelations($projectId, $active = 'true')
     {
         return $this->GET('projects/'.$projectId.'/project_users');
     }
-    
+
     public function getProjectTasks($projectId, $active = 'true')
     {
         return $this->GET('projects/'.$projectId.'/tasks');
@@ -246,9 +246,9 @@ class TogglApi
     {
         return $this->GET('projects/'.$projectId);
     }
-    
+
     /* 	DASHBOARD (https://github.com/toggl/toggl_api_docs/blob/master/chapters/dashboard.md)
-	
+
 		Dashboard's main purpose is to give an overview of what users in the workspace are doing and have been doing. Dashboard request returns two objects:
 
 		Activity
@@ -264,16 +264,16 @@ class TogglApi
 		The most active user object holds the data of the top 5 users who have tracked the most time during last 7 days. Most active user object has the following properties
 
 		user_id: user ID
-		duration: Sum of time entry durations that have been created during last 7 days	
+		duration: Sum of time entry durations that have been created during last 7 days
 	*/
-    
+
     public function getDashboadForWorkspace($workspaceId)
     {
         return $this->GET('dashboard/'.$workspaceId);
     }
-    
+
     /* 	USERS (https://github.com/toggl/toggl_api_docs/blob/master/chapters/users.md)
-	
+
 		User has the following properties
 
 		api_token: (string)
@@ -297,29 +297,29 @@ class TogglApi
 		timezone: (string) timezone user has set on the "My profile" page ( IANA TZ timezones )
 
 	*/
-    
+
     public function getMe($related = false)
     {
         return $this->GET('me', [], ['with_related_data' => $related]);
     }
-    
+
     public function updateMe($user)
     {
         return $this->PUT('me', ['user' => $user]);
     }
-    
+
     public function signup($user)
     {
         return $this->POST('signups', ['user' => $user]);
     }
-    
+
     public function resetApiToken()
     {
         return $this->POST('reset_token');
     }
-    
+
     /*	WORKSPACES (https://github.com/toggl/toggl_api_docs/blob/master/chapters/workspaces.md)
-	
+
 		Workspace has the following properties
 
 		name: the name of the workspace (string)
@@ -332,49 +332,49 @@ class TogglApi
 		rounding: type of rounding (integer)
 		rounding_minutes: round up to nearest minute (integer)
 		at: timestamp that indicates the time workspace was last updated
-		logo_url: URL pointing to the logo (if set, otherwise omited) (string)	
+		logo_url: URL pointing to the logo (if set, otherwise omited) (string)
 	*/
-    
+
     public function getWorkspaces()
     {
         return $this->GET('workspaces');
     }
-    
+
     public function getWorkspace($wid)
     {
         return $this->GET('workspaces/'.$wid);
     }
-    
+
     public function updateWorkspace($wid, $workspace)
     {
         return $this->PUT('workspaces/'.$wid, ['workspace' => $workspace]);
     }
-    
+
     public function getWorkspaceUsers($wid)
     {
         return $this->GET('workspaces/'.$wid.'/users');
     }
-    
+
     public function getWorkspaceClients($wid)
     {
         return $this->GET('workspaces/'.$wid.'/clients');
     }
-    
+
     public function getWorkspaceProjects($wid)
     {
         return $this->GET('workspaces/'.$wid.'/projects');
     }
-    
+
     public function getWorkspaceTasks($wid)
     {
         return $this->GET('workspaces/'.$wid.'/tasks');
     }
-    
+
     public function getWorkspaceTags($wid)
     {
         return $this->GET('workspaces/'.$wid.'/tags');
     }
-    
+
     /* 	WORKSPACE USERS (https://github.com/toggl/toggl_api_docs/blob/master/chapters/workspace_users.md)
 		Workspace user has the following properties:
 
@@ -384,52 +384,52 @@ class TogglApi
 		active: if the workspace user has accepted the invitation to this workspace (boolean)
 		invite_url: if user has not accepted the invitation the url for accepting his/her invitation is sent when the request is made by workspace_admin
 	*/
-    
+
     public function inviteUsersToWorkspace($wid, $emails)
     {
         return $this->POST('workspaces/'.$wid.'/invite', ['emails' => $emails]);
     }
-    
+
     public function updateWorkspaceUser($workspaceUserId, $user)
     {
         return $this->PUT('workspace_users/'.$workspaceUserId, ['workspace_user' => $user]);
     }
-    
+
     public function deleteWorkspaceUser($workspaceUserId)
     {
         return $this->DELETE('workspace_users/'.$workspaceUserId);
     }
-    
+
     public function getWorkspaceUserRelations($wid)
     {
         return $this->GET('workspaces/'.$wid.'/workspace_users');
     }
-    
+
     /*  TAGS (https://github.com/toggl/toggl_api_docs/blob/master/chapters/tags.md)
-	
+
 		Tag has the following properties
-		
+
 		name: The name of the tag (string, required, unique in workspace)
 		wid: workspace ID, where the tag will be used (integer, required)
 	*/
-    
+
     public function createTag($tag)
     {
         return $this->POST('tags', ['tag' => $tag]);
     }
-    
+
     public function updateTag($tagId, $tag)
     {
         return $this->PUT('tags/'.$tagId, ['tag' => $tag]);
     }
-    
+
     public function deleteTag($tagId)
     {
         return $this->DELETE('tags/'.$tagId);
     }
-    
+
     /*  TAGS (https://github.com/toggl/toggl_api_docs/blob/master/chapters/tags.md)
-	
+
 		Tasks are available only for pro workspaces.
 
 		Task has the following properties
@@ -444,39 +444,39 @@ class TogglApi
 		tracked_seconds: total time tracked (in seconds) for the task
 		Workspace id (wid) and project id (pid) can't be changed on update.
 	*/
-    
+
     public function getTask($taskId)
     {
         return $this->GET('tasks/'.$taskId);
     }
-    
+
     public function createTask($task)
     {
         return $this->POST('tasks', ['task' => $task]);
     }
-    
+
     public function updateTask($taskId, $task)
     {
         return $this->PUT('tasks/'.$taskId, ['task' => $task]);
     }
-    
+
     public function updateTasks($taskIds, $task)
     {
         return $this->PUT('tasks/'.implode(',', $taskIds), ['task' => $task]);
     }
-    
+
     public function deleteTask($taskId)
     {
         return $this->DELETE('tasks/'.$taskId);
     }
-    
+
     public function deleteTasks($taskIds)
     {
         return $this->DELETE('tasks/'.implode(',', $taskIds));
     }
-    
+
     /* 	TIME ENTRIES (https://github.com/toggl/toggl_api_docs/blob/master/chapters/time_entries.md)
-		
+
 		The requests are scoped with the user whose API token is used. Only his/her time entries are updated, retrieved and created.
 
 		Time entry has the following properties
@@ -494,52 +494,52 @@ class TogglApi
 		duronly: should Toggl show the start and stop time of this time entry? (boolean, not required)
 		at: timestamp that is sent in the response, indicates the time item was last updated
 	*/
-    
+
     public function createTimeEntry($entry)
     {
         return $this->POST('time_entries', ['time_entry' => $entry]);
     }
-    
+
     public function startTimeEntry($entry)
     {
         return $this->POST('time_entries/start', ['time_entry' => $entry]);
     }
-    
+
     public function stopTimeEntry($timeEntryId)
     {
         return $this->PUT('time_entries/'.$timeEntryId.'/stop');
     }
-    
+
     public function getTimeEntry($timeEntryId)
     {
         return $this->GET('time_entries/'.$timeEntryId);
     }
-    
+
     public function getRunningTimeEntry()
     {
         return $this->GET('time_entries/current');
     }
-    
+
     public function getTimeEntries()
     {
         return $this->GET('time_entries');
     }
-    
+
     public function getTimeEntriesInRange($start, $end)
     {
         return $this->GET('time_entries', [], ['start_date' => $start, 'end_date' => $end]);
     }
-    
+
     public function updateTagsForTimeEntries($timeEntryIds, $entry)
     {
         return $this->PUT('time_entries/'.implode(',', $timeEntryIds), ['time_entry' => $entry]);
     }
-    
+
     public function updateTimeEntry($timeEntryId, $entry)
     {
         return $this->PUT('time_entries/'.$timeEntryId, ['time_entry' => $entry]);
     }
-    
+
     public function deleteTimeEntry($timeEntryId)
     {
         return $this->DELETE('time_entries/'.$timeEntryId);

--- a/src/TogglApi.php
+++ b/src/TogglApi.php
@@ -5,84 +5,92 @@ namespace MorningTrain\TogglApi;
 use GuzzleHttp\Client;
 use GuzzleHttp\Exception\ClientException;
 
-class TogglApi {
-	
-	protected $api_token = '';
-	
-	protected $client;
-	
-	public function __construct($api_token) {
-		$this->api_token = $api_token;
-		$this->client = new Client([
-			'base_uri' => 'https://www.toggl.com/api/v8/',
-			'auth' => [$this->api_token, 'api_token']
-		]);		
-	}
-	
-	private function GET($endpoint, $body = array(), $query = array()){
-		try {
-			$response = $this->client->get($endpoint, ['body' => json_encode($body), 'query' => $query]);
-			return $this->checkResponse($response);
-		} catch (ClientException $e) {
-			return (object) [
-				'success' => false,
-				'message' => $e->getMessage()
-			];
-		}
-	}
-	
-	private function POST($endpoint, $body = array(), $query = array()){
-		try {
-			$response = $this->client->post($endpoint, ['body' => json_encode($body), 'query' => $query]);
-			return $this->checkResponse($response);
-		} catch (ClientException $e) {
-			return (object) [
-				'success' => false,
-				'message' => $e->getMessage()
-			];
-		}
-	}
-	
-	private function PUT($endpoint, $body = array(), $query = array()){
-		try {
-			$response = $this->client->put($endpoint, ['body' => json_encode($body), 'query' => $query]);
-			return $this->checkResponse($response);
-		} catch (ClientException $e) {
-			return (object) [
-				'success' => false,
-				'message' => $e->getMessage()
-			];
-		}
-	}
-	
-	private function DELETE($endpoint, $body = array(), $query = array()){
-		try {
-			$response = $this->client->delete($endpoint, ['body' => json_encode($body), 'query' => $query]);
-			return $this->checkResponse($response);
-		} catch (ClientException $e) {
-			return (object) [
-				'success' => false,
-				'message' => $e->getMessage()
-			];
-		}
-	}
-	
-	private function checkResponse($response) {
-		if($response->getStatusCode() == 200) {
-			$data = json_decode($response->getBody());
-			if(is_object($data) && isset($data->data)){
-				$data = $data->data;
-			}
-			return $data;
-		}
-		return false;
-	}
-	
-	public function getAvailableEndpoints(){
-		return $this->get('');
-	}
-	
-	/* 	CLIENTS (https://github.com/toggl/toggl_api_docs/blob/master/chapters/clients.md)
+class TogglApi
+{
+    
+    protected $api_token = '';
+    
+    protected $client;
+    
+    public function __construct($api_token)
+    {
+        $this->api_token = $api_token;
+        $this->client = new Client([
+            'base_uri' => 'https://www.toggl.com/api/v8/',
+            'auth' => [$this->api_token, 'api_token']
+        ]);
+    }
+    
+    private function GET($endpoint, $body = array(), $query = array())
+    {
+        try {
+            $response = $this->client->get($endpoint, ['body' => json_encode($body), 'query' => $query]);
+            return $this->checkResponse($response);
+        } catch (ClientException $e) {
+            return (object) [
+                'success' => false,
+                'message' => $e->getMessage()
+            ];
+        }
+    }
+    
+    private function POST($endpoint, $body = array(), $query = array())
+    {
+        try {
+            $response = $this->client->post($endpoint, ['body' => json_encode($body), 'query' => $query]);
+            return $this->checkResponse($response);
+        } catch (ClientException $e) {
+            return (object) [
+                'success' => false,
+                'message' => $e->getMessage()
+            ];
+        }
+    }
+    
+    private function PUT($endpoint, $body = array(), $query = array())
+    {
+        try {
+            $response = $this->client->put($endpoint, ['body' => json_encode($body), 'query' => $query]);
+            return $this->checkResponse($response);
+        } catch (ClientException $e) {
+            return (object) [
+                'success' => false,
+                'message' => $e->getMessage()
+            ];
+        }
+    }
+    
+    private function DELETE($endpoint, $body = array(), $query = array())
+    {
+        try {
+            $response = $this->client->delete($endpoint, ['body' => json_encode($body), 'query' => $query]);
+            return $this->checkResponse($response);
+        } catch (ClientException $e) {
+            return (object) [
+                'success' => false,
+                'message' => $e->getMessage()
+            ];
+        }
+    }
+    
+    private function checkResponse($response)
+    {
+        if ($response->getStatusCode() == 200) {
+            $data = json_decode($response->getBody());
+            if (is_object($data) && isset($data->data)) {
+                $data = $data->data;
+            }
+            return $data;
+        }
+        return false;
+    }
+    
+    public function getAvailableEndpoints()
+    {
+        return $this->get('');
+    }
+    
+    /* 	CLIENTS (https://github.com/toggl/toggl_api_docs/blob/master/chapters/clients.md)
 	
 		Client has the following properties
 
@@ -93,44 +101,53 @@ class TogglApi {
 		cur: The name of the client's currency (string, not required, available only for pro workspaces)
 		at: timestamp that is sent in the response, indicates the time client was last updated
 	*/
-	
-	public function createClient($client){
-		return $this->POST('clients', ['client' => $client]);
-	}
-	
-	public function updateClient($clientId, $client){
-		return $this->PUT('clients/' . $clientId, ['client' => $client]);
-	}
-	
-	public function deleteClient($clientId){
-		return $this->DELETE('clients/' . $clientId);
-	}
-	
-	public function getClients(){
-		return $this->GET('clients');
-	}
-	
-	public function getClientProjects($clientId){
-		return $this->GET('clients/' . $clientId . '/projects');
-	}
-	
-	public function getActiveClientProjects($clientId){
-		return $this->GET('clients/' . $clientId . '/projects?active=true');
-	}
-	
-	public function getInactiveClientProjects($clientId){
-		return $this->GET('clients/' . $clientId . '/projects?active=false');
-	}
-	
-	public function getAllClientProjects($clientId){
-		return $this->GET('clients/' . $clientId . '/projects?active=both');
-	}
-	
-	public function getClientById($clientId){
-		return $this->GET('clients/' . $clientId);
-	}
-	
-	/* 	PROJECTS USERS (https://github.com/toggl/toggl_api_docs/blob/master/chapters/project_users.md)
+    
+    public function createClient($client)
+    {
+        return $this->POST('clients', ['client' => $client]);
+    }
+    
+    public function updateClient($clientId, $client)
+    {
+        return $this->PUT('clients/' . $clientId, ['client' => $client]);
+    }
+    
+    public function deleteClient($clientId)
+    {
+        return $this->DELETE('clients/' . $clientId);
+    }
+    
+    public function getClients()
+    {
+        return $this->GET('clients');
+    }
+    
+    public function getClientProjects($clientId)
+    {
+        return $this->GET('clients/' . $clientId . '/projects');
+    }
+    
+    public function getActiveClientProjects($clientId)
+    {
+        return $this->GET('clients/' . $clientId . '/projects?active=true');
+    }
+    
+    public function getInactiveClientProjects($clientId)
+    {
+        return $this->GET('clients/' . $clientId . '/projects?active=false');
+    }
+    
+    public function getAllClientProjects($clientId)
+    {
+        return $this->GET('clients/' . $clientId . '/projects?active=both');
+    }
+    
+    public function getClientById($clientId)
+    {
+        return $this->GET('clients/' . $clientId);
+    }
+    
+    /* 	PROJECTS USERS (https://github.com/toggl/toggl_api_docs/blob/master/chapters/project_users.md)
 	
 		Project user has the following properties
 
@@ -143,32 +160,38 @@ class TogglApi {
 		Workspace id (wid), project id (pid) and user id (uid) can't be changed on update.
 
 	*/
-	
-	public function createProjectUser($user){
-		return $this->POST('project_users', ['project_user' => $user]);
-	}
-	
-	public function createProjectUsers($user){
-		return $this->POST('project_users', ['project_user' => $user]);
-	}
-	
-	public function updateProjectUser($projectUserId, $user){
-		return $this->PUT('project_users/' . $projectUserId, ['project_user' => $user]);
-	}
-	
-	public function updateProjectUsers($projectUserIds, $user){
-		return $this->PUT('project_users/' . implode(',', $projectUserIds), ['project_user' => $user]);
-	}
-	
-	public function deleteProjectUser($projectUserId){
-		return $this->DELETE('project_users/' . $projectUserId);
-	}
-	
-	public function deleteProjectUsers($projectUserIds){
-		return $this->DELETE('project_users/' . implode(',', $projectUserIds));
-	}
-	
-	/* 	PROJECTS (https://github.com/toggl/toggl_api_docs/blob/master/chapters/projects.md)
+    
+    public function createProjectUser($user)
+    {
+        return $this->POST('project_users', ['project_user' => $user]);
+    }
+    
+    public function createProjectUsers($user)
+    {
+        return $this->POST('project_users', ['project_user' => $user]);
+    }
+    
+    public function updateProjectUser($projectUserId, $user)
+    {
+        return $this->PUT('project_users/' . $projectUserId, ['project_user' => $user]);
+    }
+    
+    public function updateProjectUsers($projectUserIds, $user)
+    {
+        return $this->PUT('project_users/' . implode(',', $projectUserIds), ['project_user' => $user]);
+    }
+    
+    public function deleteProjectUser($projectUserId)
+    {
+        return $this->DELETE('project_users/' . $projectUserId);
+    }
+    
+    public function deleteProjectUsers($projectUserIds)
+    {
+        return $this->DELETE('project_users/' . implode(',', $projectUserIds));
+    }
+    
+    /* 	PROJECTS (https://github.com/toggl/toggl_api_docs/blob/master/chapters/projects.md)
 	
 		Project has the following properties
 
@@ -188,36 +211,43 @@ class TogglApi {
 		created_at: timestamp indicating when the project was created (UTC time), read-only
 
 	*/
-	
-	public function createProject($project){
-		return $this->POST('projects', ['project' => $project]);
-	}
-	
-	public function updateProject($projectId, $project){
-		return $this->PUT('projects/' . $projectId, ['project' => $project]);
-	}
-	
-	public function deleteProject($projectId){
-		return $this->DELETE('projects/' . $projectId);
-	}
-	
-	public function deleteProjects($projectIds){
-		return $this->DELETE('projects/' . implode(',', $projectIds));
-	}
-	
-	public function getProjectUserRelations($projectId, $active = 'true'){
-		return $this->GET('projects/' . $projectId . '/project_users');
-	}
-	
-	public function getProjectTasks($projectId, $active = 'true'){
-		return $this->GET('projects/' . $projectId . '/tasks');
-	}
+    
+    public function createProject($project)
+    {
+        return $this->POST('projects', ['project' => $project]);
+    }
+    
+    public function updateProject($projectId, $project)
+    {
+        return $this->PUT('projects/' . $projectId, ['project' => $project]);
+    }
+    
+    public function deleteProject($projectId)
+    {
+        return $this->DELETE('projects/' . $projectId);
+    }
+    
+    public function deleteProjects($projectIds)
+    {
+        return $this->DELETE('projects/' . implode(',', $projectIds));
+    }
+    
+    public function getProjectUserRelations($projectId, $active = 'true')
+    {
+        return $this->GET('projects/' . $projectId . '/project_users');
+    }
+    
+    public function getProjectTasks($projectId, $active = 'true')
+    {
+        return $this->GET('projects/' . $projectId . '/tasks');
+    }
 
-	public function getProject($projectId){
-		return $this->GET('projects/' . $projectId);
-	}
-	
-	/* 	DASHBOARD (https://github.com/toggl/toggl_api_docs/blob/master/chapters/dashboard.md)
+    public function getProject($projectId)
+    {
+        return $this->GET('projects/' . $projectId);
+    }
+    
+    /* 	DASHBOARD (https://github.com/toggl/toggl_api_docs/blob/master/chapters/dashboard.md)
 	
 		Dashboard's main purpose is to give an overview of what users in the workspace are doing and have been doing. Dashboard request returns two objects:
 
@@ -236,12 +266,13 @@ class TogglApi {
 		user_id: user ID
 		duration: Sum of time entry durations that have been created during last 7 days	
 	*/
-	
-	public function getDashboadForWorkspace($workspaceId){
-		return $this->GET('dashboard/' . $workspaceId);
-	}
-	
-	/* 	USERS (https://github.com/toggl/toggl_api_docs/blob/master/chapters/users.md)
+    
+    public function getDashboadForWorkspace($workspaceId)
+    {
+        return $this->GET('dashboard/' . $workspaceId);
+    }
+    
+    /* 	USERS (https://github.com/toggl/toggl_api_docs/blob/master/chapters/users.md)
 	
 		User has the following properties
 
@@ -265,25 +296,29 @@ class TogglApi {
 		openid_enabled: (boolean) google signin enabled
 		timezone: (string) timezone user has set on the "My profile" page ( IANA TZ timezones )
 
-	*/	
-	
-	public function getMe($related = false){
-		return $this->GET('me', [], ['with_related_data' => $related]);
-	}
-	
-	public function updateMe($user){
-		return $this->PUT('me', ['user' => $user]);
-	}
-	
-	public function signup($user){
-		return $this->POST('signups', ['user' => $user]);
-	}
-	
-	public function resetApiToken(){
-		return $this->POST('reset_token');
-	}
-	
-	/*	WORKSPACES (https://github.com/toggl/toggl_api_docs/blob/master/chapters/workspaces.md)
+	*/
+    
+    public function getMe($related = false)
+    {
+        return $this->GET('me', [], ['with_related_data' => $related]);
+    }
+    
+    public function updateMe($user)
+    {
+        return $this->PUT('me', ['user' => $user]);
+    }
+    
+    public function signup($user)
+    {
+        return $this->POST('signups', ['user' => $user]);
+    }
+    
+    public function resetApiToken()
+    {
+        return $this->POST('reset_token');
+    }
+    
+    /*	WORKSPACES (https://github.com/toggl/toggl_api_docs/blob/master/chapters/workspaces.md)
 	
 		Workspace has the following properties
 
@@ -299,40 +334,48 @@ class TogglApi {
 		at: timestamp that indicates the time workspace was last updated
 		logo_url: URL pointing to the logo (if set, otherwise omited) (string)	
 	*/
-	
-	public function getWorkspaces(){
-		return $this->GET('workspaces');
-	}
-	
-	public function getWorkspace($wid){
-		return $this->GET('workspaces/' . $wid);
-	}
-	
-	public function updateWorkspace($wid, $workspace){
-		return $this->PUT('workspaces/' . $wid, ['workspace' => $workspace]);
-	}
-	
-	public function getWorkspaceUsers($wid){
-		return $this->GET('workspaces/' . $wid . '/users');
-	}
-	
-	public function getWorkspaceClients($wid){
-		return $this->GET('workspaces/' . $wid . '/clients');
-	}
-	
-	public function getWorkspaceProjects($wid){
-		return $this->GET('workspaces/' . $wid . '/projects');
-	}
-	
-	public function getWorkspaceTasks($wid){
-		return $this->GET('workspaces/' . $wid . '/tasks');
-	}
-	
-	public function getWorkspaceTags($wid){
-		return $this->GET('workspaces/' . $wid . '/tags');
-	}
-	
-	/* 	WORKSPACE USERS (https://github.com/toggl/toggl_api_docs/blob/master/chapters/workspace_users.md)
+    
+    public function getWorkspaces()
+    {
+        return $this->GET('workspaces');
+    }
+    
+    public function getWorkspace($wid)
+    {
+        return $this->GET('workspaces/' . $wid);
+    }
+    
+    public function updateWorkspace($wid, $workspace)
+    {
+        return $this->PUT('workspaces/' . $wid, ['workspace' => $workspace]);
+    }
+    
+    public function getWorkspaceUsers($wid)
+    {
+        return $this->GET('workspaces/' . $wid . '/users');
+    }
+    
+    public function getWorkspaceClients($wid)
+    {
+        return $this->GET('workspaces/' . $wid . '/clients');
+    }
+    
+    public function getWorkspaceProjects($wid)
+    {
+        return $this->GET('workspaces/' . $wid . '/projects');
+    }
+    
+    public function getWorkspaceTasks($wid)
+    {
+        return $this->GET('workspaces/' . $wid . '/tasks');
+    }
+    
+    public function getWorkspaceTags($wid)
+    {
+        return $this->GET('workspaces/' . $wid . '/tags');
+    }
+    
+    /* 	WORKSPACE USERS (https://github.com/toggl/toggl_api_docs/blob/master/chapters/workspace_users.md)
 		Workspace user has the following properties:
 
 		id: workspace user id (integer)
@@ -341,44 +384,51 @@ class TogglApi {
 		active: if the workspace user has accepted the invitation to this workspace (boolean)
 		invite_url: if user has not accepted the invitation the url for accepting his/her invitation is sent when the request is made by workspace_admin
 	*/
-	
-	public function inviteUsersToWorkspace($wid, $emails){
-		return $this->POST('workspaces/' . $wid . '/invite', ['emails' => $emails]);
-	}
-	
-	public function updateWorkspaceUser($workspaceUserId, $user){
-		return $this->PUT('workspace_users/' . $workspaceUserId, ['workspace_user' => $user]);
-	}
-	
-	public function deleteWorkspaceUser($workspaceUserId){
-		return $this->DELETE('workspace_users/' . $workspaceUserId);	
-	}
-	
-	public function getWorkspaceUserRelations($wid){
-		return $this->GET('workspaces/' . $wid . '/workspace_users');
-	}
-	
-	/* 	TAGS (https://github.com/toggl/toggl_api_docs/blob/master/chapters/tags.md) 
+    
+    public function inviteUsersToWorkspace($wid, $emails)
+    {
+        return $this->POST('workspaces/' . $wid . '/invite', ['emails' => $emails]);
+    }
+    
+    public function updateWorkspaceUser($workspaceUserId, $user)
+    {
+        return $this->PUT('workspace_users/' . $workspaceUserId, ['workspace_user' => $user]);
+    }
+    
+    public function deleteWorkspaceUser($workspaceUserId)
+    {
+        return $this->DELETE('workspace_users/' . $workspaceUserId);
+    }
+    
+    public function getWorkspaceUserRelations($wid)
+    {
+        return $this->GET('workspaces/' . $wid . '/workspace_users');
+    }
+    
+    /*  TAGS (https://github.com/toggl/toggl_api_docs/blob/master/chapters/tags.md)
 	
 		Tag has the following properties
 		
 		name: The name of the tag (string, required, unique in workspace)
 		wid: workspace ID, where the tag will be used (integer, required)
 	*/
-	
-	public function createTag($tag){
-		return $this->POST('tags', ['tag' => $tag]);
-	}
-	
-	public function updateTag($tagId, $tag){
-		return $this->PUT('tags/' . $tagId, ['tag' => $tag]);
-	}
-	
-	public function deleteTag($tagId){
-		return $this->DELETE('tags/' . $tagId);
-	}
-	
-	/* 	TAGS (https://github.com/toggl/toggl_api_docs/blob/master/chapters/tags.md) 
+    
+    public function createTag($tag)
+    {
+        return $this->POST('tags', ['tag' => $tag]);
+    }
+    
+    public function updateTag($tagId, $tag)
+    {
+        return $this->PUT('tags/' . $tagId, ['tag' => $tag]);
+    }
+    
+    public function deleteTag($tagId)
+    {
+        return $this->DELETE('tags/' . $tagId);
+    }
+    
+    /*  TAGS (https://github.com/toggl/toggl_api_docs/blob/master/chapters/tags.md)
 	
 		Tasks are available only for pro workspaces.
 
@@ -394,32 +444,38 @@ class TogglApi {
 		tracked_seconds: total time tracked (in seconds) for the task
 		Workspace id (wid) and project id (pid) can't be changed on update.
 	*/
-	
-	public function getTask($taskId){
-		return $this->GET('tasks/' . $taskId);
-	}
-	
-	public function createTask($task){
-		return $this->POST('tasks', ['task' => $task]);
-	}
-	
-	public function updateTask($taskId, $task){
-		return $this->PUT('tasks/' . $taskId, ['task' => $task]);
-	}
-	
-	public function updateTasks($taskIds, $task){
-		return $this->PUT('tasks/' . implode(',', $taskIds), ['task' => $task]);
-	}
-	
-	public function deleteTask($taskId){
-		return $this->DELETE('tasks/' . $taskId);
-	}
-	
-	public function deleteTasks($taskIds){
-		return $this->DELETE('tasks/' . implode(',', $taskIds));
-	}
-	
-	/* 	TIME ENTRIES (https://github.com/toggl/toggl_api_docs/blob/master/chapters/time_entries.md)
+    
+    public function getTask($taskId)
+    {
+        return $this->GET('tasks/' . $taskId);
+    }
+    
+    public function createTask($task)
+    {
+        return $this->POST('tasks', ['task' => $task]);
+    }
+    
+    public function updateTask($taskId, $task)
+    {
+        return $this->PUT('tasks/' . $taskId, ['task' => $task]);
+    }
+    
+    public function updateTasks($taskIds, $task)
+    {
+        return $this->PUT('tasks/' . implode(',', $taskIds), ['task' => $task]);
+    }
+    
+    public function deleteTask($taskId)
+    {
+        return $this->DELETE('tasks/' . $taskId);
+    }
+    
+    public function deleteTasks($taskIds)
+    {
+        return $this->DELETE('tasks/' . implode(',', $taskIds));
+    }
+    
+    /* 	TIME ENTRIES (https://github.com/toggl/toggl_api_docs/blob/master/chapters/time_entries.md)
 		
 		The requests are scoped with the user whose API token is used. Only his/her time entries are updated, retrieved and created.
 
@@ -438,47 +494,54 @@ class TogglApi {
 		duronly: should Toggl show the start and stop time of this time entry? (boolean, not required)
 		at: timestamp that is sent in the response, indicates the time item was last updated
 	*/
-	
-	public function createTimeEntry($entry){
-		return $this->POST('time_entries', ['time_entry' => $entry]);
-	}	
-	
-	public function startTimeEntry($entry){
-		return $this->POST('time_entries/start', ['time_entry' => $entry]);
-	}	
-	
-	public function stopTimeEntry($timeEntryId){
-		return $this->PUT('time_entries/' . $timeEntryId.'/stop');
-	}
-	
-	public function getTimeEntry($timeEntryId){
-		return $this->GET('time_entries/' . $timeEntryId);
-	}	
-	
-	public function getRunningTimeEntry(){
-		return $this->GET('time_entries/current');
-	}
-	
-	public function getTimeEntries(){
-		return $this->GET('time_entries');
-	}	
-	
-	public function getTimeEntriesInRange($start, $end){
-		return $this->GET('time_entries', [], ['start_date' => $start, 'end_date' => $end]);
-	}	
-	
-	public function updateTagsForTimeEntries($timeEntryIds, $entry){
-		return $this->PUT('time_entries/' . implode(',', $timeEntryIds), ['time_entry' => $entry]);
-	}
-	
-	public function updateTimeEntry($timeEntryId, $entry){
-		return $this->PUT('time_entries/' . $timeEntryId, ['time_entry' => $entry]);
-	}	
-	
-	public function deleteTimeEntry($timeEntryId){
-		return $this->DELETE('time_entries/' . $timeEntryId);
-	}	
-	
+    
+    public function createTimeEntry($entry)
+    {
+        return $this->POST('time_entries', ['time_entry' => $entry]);
+    }
+    
+    public function startTimeEntry($entry)
+    {
+        return $this->POST('time_entries/start', ['time_entry' => $entry]);
+    }
+    
+    public function stopTimeEntry($timeEntryId)
+    {
+        return $this->PUT('time_entries/' . $timeEntryId.'/stop');
+    }
+    
+    public function getTimeEntry($timeEntryId)
+    {
+        return $this->GET('time_entries/' . $timeEntryId);
+    }
+    
+    public function getRunningTimeEntry()
+    {
+        return $this->GET('time_entries/current');
+    }
+    
+    public function getTimeEntries()
+    {
+        return $this->GET('time_entries');
+    }
+    
+    public function getTimeEntriesInRange($start, $end)
+    {
+        return $this->GET('time_entries', [], ['start_date' => $start, 'end_date' => $end]);
+    }
+    
+    public function updateTagsForTimeEntries($timeEntryIds, $entry)
+    {
+        return $this->PUT('time_entries/' . implode(',', $timeEntryIds), ['time_entry' => $entry]);
+    }
+    
+    public function updateTimeEntry($timeEntryId, $entry)
+    {
+        return $this->PUT('time_entries/' . $timeEntryId, ['time_entry' => $entry]);
+    }
+    
+    public function deleteTimeEntry($timeEntryId)
+    {
+        return $this->DELETE('time_entries/' . $timeEntryId);
+    }
 }
-
-?>

--- a/src/TogglApi.php
+++ b/src/TogglApi.php
@@ -109,12 +109,12 @@ class TogglApi
     
     public function updateClient($clientId, $client)
     {
-        return $this->PUT('clients/' . $clientId, ['client' => $client]);
+        return $this->PUT('clients/'.$clientId, ['client' => $client]);
     }
     
     public function deleteClient($clientId)
     {
-        return $this->DELETE('clients/' . $clientId);
+        return $this->DELETE('clients/'.$clientId);
     }
     
     public function getClients()
@@ -124,27 +124,27 @@ class TogglApi
     
     public function getClientProjects($clientId)
     {
-        return $this->GET('clients/' . $clientId . '/projects');
+        return $this->GET('clients/'.$clientId.'/projects');
     }
     
     public function getActiveClientProjects($clientId)
     {
-        return $this->GET('clients/' . $clientId . '/projects?active=true');
+        return $this->GET('clients/'.$clientId.'/projects?active=true');
     }
     
     public function getInactiveClientProjects($clientId)
     {
-        return $this->GET('clients/' . $clientId . '/projects?active=false');
+        return $this->GET('clients/'.$clientId.'/projects?active=false');
     }
     
     public function getAllClientProjects($clientId)
     {
-        return $this->GET('clients/' . $clientId . '/projects?active=both');
+        return $this->GET('clients/'.$clientId.'/projects?active=both');
     }
     
     public function getClientById($clientId)
     {
-        return $this->GET('clients/' . $clientId);
+        return $this->GET('clients/'.$clientId);
     }
     
     /* 	PROJECTS USERS (https://github.com/toggl/toggl_api_docs/blob/master/chapters/project_users.md)
@@ -173,22 +173,22 @@ class TogglApi
     
     public function updateProjectUser($projectUserId, $user)
     {
-        return $this->PUT('project_users/' . $projectUserId, ['project_user' => $user]);
+        return $this->PUT('project_users/'.$projectUserId, ['project_user' => $user]);
     }
     
     public function updateProjectUsers($projectUserIds, $user)
     {
-        return $this->PUT('project_users/' . implode(',', $projectUserIds), ['project_user' => $user]);
+        return $this->PUT('project_users/'.implode(',', $projectUserIds), ['project_user' => $user]);
     }
     
     public function deleteProjectUser($projectUserId)
     {
-        return $this->DELETE('project_users/' . $projectUserId);
+        return $this->DELETE('project_users/'.$projectUserId);
     }
     
     public function deleteProjectUsers($projectUserIds)
     {
-        return $this->DELETE('project_users/' . implode(',', $projectUserIds));
+        return $this->DELETE('project_users/'.implode(',', $projectUserIds));
     }
     
     /* 	PROJECTS (https://github.com/toggl/toggl_api_docs/blob/master/chapters/projects.md)
@@ -219,32 +219,32 @@ class TogglApi
     
     public function updateProject($projectId, $project)
     {
-        return $this->PUT('projects/' . $projectId, ['project' => $project]);
+        return $this->PUT('projects/'.$projectId, ['project' => $project]);
     }
     
     public function deleteProject($projectId)
     {
-        return $this->DELETE('projects/' . $projectId);
+        return $this->DELETE('projects/'.$projectId);
     }
     
     public function deleteProjects($projectIds)
     {
-        return $this->DELETE('projects/' . implode(',', $projectIds));
+        return $this->DELETE('projects/'.implode(',', $projectIds));
     }
     
     public function getProjectUserRelations($projectId, $active = 'true')
     {
-        return $this->GET('projects/' . $projectId . '/project_users');
+        return $this->GET('projects/'.$projectId.'/project_users');
     }
     
     public function getProjectTasks($projectId, $active = 'true')
     {
-        return $this->GET('projects/' . $projectId . '/tasks');
+        return $this->GET('projects/'.$projectId.'/tasks');
     }
 
     public function getProject($projectId)
     {
-        return $this->GET('projects/' . $projectId);
+        return $this->GET('projects/'.$projectId);
     }
     
     /* 	DASHBOARD (https://github.com/toggl/toggl_api_docs/blob/master/chapters/dashboard.md)
@@ -269,7 +269,7 @@ class TogglApi
     
     public function getDashboadForWorkspace($workspaceId)
     {
-        return $this->GET('dashboard/' . $workspaceId);
+        return $this->GET('dashboard/'.$workspaceId);
     }
     
     /* 	USERS (https://github.com/toggl/toggl_api_docs/blob/master/chapters/users.md)
@@ -342,37 +342,37 @@ class TogglApi
     
     public function getWorkspace($wid)
     {
-        return $this->GET('workspaces/' . $wid);
+        return $this->GET('workspaces/'.$wid);
     }
     
     public function updateWorkspace($wid, $workspace)
     {
-        return $this->PUT('workspaces/' . $wid, ['workspace' => $workspace]);
+        return $this->PUT('workspaces/'.$wid, ['workspace' => $workspace]);
     }
     
     public function getWorkspaceUsers($wid)
     {
-        return $this->GET('workspaces/' . $wid . '/users');
+        return $this->GET('workspaces/'.$wid.'/users');
     }
     
     public function getWorkspaceClients($wid)
     {
-        return $this->GET('workspaces/' . $wid . '/clients');
+        return $this->GET('workspaces/'.$wid.'/clients');
     }
     
     public function getWorkspaceProjects($wid)
     {
-        return $this->GET('workspaces/' . $wid . '/projects');
+        return $this->GET('workspaces/'.$wid.'/projects');
     }
     
     public function getWorkspaceTasks($wid)
     {
-        return $this->GET('workspaces/' . $wid . '/tasks');
+        return $this->GET('workspaces/'.$wid.'/tasks');
     }
     
     public function getWorkspaceTags($wid)
     {
-        return $this->GET('workspaces/' . $wid . '/tags');
+        return $this->GET('workspaces/'.$wid.'/tags');
     }
     
     /* 	WORKSPACE USERS (https://github.com/toggl/toggl_api_docs/blob/master/chapters/workspace_users.md)
@@ -387,22 +387,22 @@ class TogglApi
     
     public function inviteUsersToWorkspace($wid, $emails)
     {
-        return $this->POST('workspaces/' . $wid . '/invite', ['emails' => $emails]);
+        return $this->POST('workspaces/'.$wid.'/invite', ['emails' => $emails]);
     }
     
     public function updateWorkspaceUser($workspaceUserId, $user)
     {
-        return $this->PUT('workspace_users/' . $workspaceUserId, ['workspace_user' => $user]);
+        return $this->PUT('workspace_users/'.$workspaceUserId, ['workspace_user' => $user]);
     }
     
     public function deleteWorkspaceUser($workspaceUserId)
     {
-        return $this->DELETE('workspace_users/' . $workspaceUserId);
+        return $this->DELETE('workspace_users/'.$workspaceUserId);
     }
     
     public function getWorkspaceUserRelations($wid)
     {
-        return $this->GET('workspaces/' . $wid . '/workspace_users');
+        return $this->GET('workspaces/'.$wid.'/workspace_users');
     }
     
     /*  TAGS (https://github.com/toggl/toggl_api_docs/blob/master/chapters/tags.md)
@@ -420,12 +420,12 @@ class TogglApi
     
     public function updateTag($tagId, $tag)
     {
-        return $this->PUT('tags/' . $tagId, ['tag' => $tag]);
+        return $this->PUT('tags/'.$tagId, ['tag' => $tag]);
     }
     
     public function deleteTag($tagId)
     {
-        return $this->DELETE('tags/' . $tagId);
+        return $this->DELETE('tags/'.$tagId);
     }
     
     /*  TAGS (https://github.com/toggl/toggl_api_docs/blob/master/chapters/tags.md)
@@ -447,7 +447,7 @@ class TogglApi
     
     public function getTask($taskId)
     {
-        return $this->GET('tasks/' . $taskId);
+        return $this->GET('tasks/'.$taskId);
     }
     
     public function createTask($task)
@@ -457,22 +457,22 @@ class TogglApi
     
     public function updateTask($taskId, $task)
     {
-        return $this->PUT('tasks/' . $taskId, ['task' => $task]);
+        return $this->PUT('tasks/'.$taskId, ['task' => $task]);
     }
     
     public function updateTasks($taskIds, $task)
     {
-        return $this->PUT('tasks/' . implode(',', $taskIds), ['task' => $task]);
+        return $this->PUT('tasks/'.implode(',', $taskIds), ['task' => $task]);
     }
     
     public function deleteTask($taskId)
     {
-        return $this->DELETE('tasks/' . $taskId);
+        return $this->DELETE('tasks/'.$taskId);
     }
     
     public function deleteTasks($taskIds)
     {
-        return $this->DELETE('tasks/' . implode(',', $taskIds));
+        return $this->DELETE('tasks/'.implode(',', $taskIds));
     }
     
     /* 	TIME ENTRIES (https://github.com/toggl/toggl_api_docs/blob/master/chapters/time_entries.md)
@@ -507,12 +507,12 @@ class TogglApi
     
     public function stopTimeEntry($timeEntryId)
     {
-        return $this->PUT('time_entries/' . $timeEntryId.'/stop');
+        return $this->PUT('time_entries/'.$timeEntryId.'/stop');
     }
     
     public function getTimeEntry($timeEntryId)
     {
-        return $this->GET('time_entries/' . $timeEntryId);
+        return $this->GET('time_entries/'.$timeEntryId);
     }
     
     public function getRunningTimeEntry()
@@ -532,16 +532,16 @@ class TogglApi
     
     public function updateTagsForTimeEntries($timeEntryIds, $entry)
     {
-        return $this->PUT('time_entries/' . implode(',', $timeEntryIds), ['time_entry' => $entry]);
+        return $this->PUT('time_entries/'.implode(',', $timeEntryIds), ['time_entry' => $entry]);
     }
     
     public function updateTimeEntry($timeEntryId, $entry)
     {
-        return $this->PUT('time_entries/' . $timeEntryId, ['time_entry' => $entry]);
+        return $this->PUT('time_entries/'.$timeEntryId, ['time_entry' => $entry]);
     }
     
     public function deleteTimeEntry($timeEntryId)
     {
-        return $this->DELETE('time_entries/' . $timeEntryId);
+        return $this->DELETE('time_entries/'.$timeEntryId);
     }
 }

--- a/src/TogglReportsApi.php
+++ b/src/TogglReportsApi.php
@@ -36,102 +36,108 @@ use GuzzleHttp\Exception\ClientException;
 
 */
 
-class TogglReportsApi {
-	
-	protected $api_token = '';
-	
-	protected $client;
-	
-	public function __construct($api_token) {
-		$this->api_token = $api_token;
-		$this->client = new Client([
-			'base_uri' => 'https://www.toggl.com/reports/api/v2/',
-			'auth' => [$this->api_token, 'api_token']
-		]);		
-	}
-	
-	private function GET($endpoint, $query = array()){		
-		try {
-			$response = $this->client->get($endpoint, ['query' => $query]);
-			return $this->checkResponse($response);
-		} catch (ClientException $e) {
-			return (object) [
-				'success' => false,
-				'message' => $e->getMessage()
-			];
-		}
-	}
-	
-	private function POST($endpoint, $query = array()){		
-		try {
-			$response = $this->client->post($endpoint, ['query' => $query]);
-			return $this->checkResponse($response);
-		} catch (ClientException $e) {
-			return (object) [
-				'success' => false,
-				'message' => $e->getMessage()
-			];
-		}
-	}
-	
-	private function PUT($endpoint, $query = array()){		
-		try {
-			$response = $this->client->put($endpoint, ['query' => $query]);
-			return $this->checkResponse($response);
-		} catch (ClientException $e) {
-			return (object) [
-				'success' => false,
-				'message' => $e->getMessage()
-			];
-		}
-	}
-	
-	private function DELETE($endpoint, $query = array()){		
-		try {
-			$response = $this->client->delete($endpoint, ['query' => $query]);
-			return $this->checkResponse($response);
-		} catch (ClientException $e) {
-			return (object) [
-				'success' => false,
-				'message' => $e->getMessage()
-			];
-		}
-	}
-	
-	private function checkResponse($response) {
-		if($response->getStatusCode() == 200) {
-			$data = json_decode($response->getBody());
-			if(is_object($data) && isset($data->data)){
-				$data = $data->data;
-			}
-			return $data;
-		}
-		return false;
-	}
-	
-	public function getAvailableEndpoints(){
-		return $this->get('');
-	}
-	
-	public function getProjectReport($query){
-		return $this->get('project', $query);
-	}
-	
-	public function getSummaryReport($query){
-		return $this->get('summary', $query);
-	}
-	
-	public function getDetailsReport($query){
-		return $this->get('details', $query);
-	}
-	
-	public function getWeeklyReport($query){
-		return $this->get('weekly', $query);
-	}
-	
-	
-	
-	
+class TogglReportsApi
+{
+    
+    protected $api_token = '';
+    
+    protected $client;
+    
+    public function __construct($api_token)
+    {
+        $this->api_token = $api_token;
+        $this->client = new Client([
+            'base_uri' => 'https://www.toggl.com/reports/api/v2/',
+            'auth' => [$this->api_token, 'api_token']
+        ]);
+    }
+    
+    private function GET($endpoint, $query = array())
+    {
+        try {
+            $response = $this->client->get($endpoint, ['query' => $query]);
+            return $this->checkResponse($response);
+        } catch (ClientException $e) {
+            return (object) [
+                'success' => false,
+                'message' => $e->getMessage()
+            ];
+        }
+    }
+    
+    private function POST($endpoint, $query = array())
+    {
+        try {
+            $response = $this->client->post($endpoint, ['query' => $query]);
+            return $this->checkResponse($response);
+        } catch (ClientException $e) {
+            return (object) [
+                'success' => false,
+                'message' => $e->getMessage()
+            ];
+        }
+    }
+    
+    private function PUT($endpoint, $query = array())
+    {
+        try {
+            $response = $this->client->put($endpoint, ['query' => $query]);
+            return $this->checkResponse($response);
+        } catch (ClientException $e) {
+            return (object) [
+                'success' => false,
+                'message' => $e->getMessage()
+            ];
+        }
+    }
+    
+    private function DELETE($endpoint, $query = array())
+    {
+        try {
+            $response = $this->client->delete($endpoint, ['query' => $query]);
+            return $this->checkResponse($response);
+        } catch (ClientException $e) {
+            return (object) [
+                'success' => false,
+                'message' => $e->getMessage()
+            ];
+        }
+    }
+    
+    private function checkResponse($response)
+    {
+        if ($response->getStatusCode() == 200) {
+            $data = json_decode($response->getBody());
+            if (is_object($data) && isset($data->data)) {
+                $data = $data->data;
+            }
+            return $data;
+        }
+        return false;
+    }
+    
+    public function getAvailableEndpoints()
+    {
+        return $this->get('');
+    }
+    
+    public function getProjectReport($query)
+    {
+        return $this->get('project', $query);
+    }
+    
+    public function getSummaryReport($query)
+    {
+        return $this->get('summary', $query);
+    }
+    
+    public function getDetailsReport($query)
+    {
+        return $this->get('details', $query);
+    }
+    
+    public function getWeeklyReport($query)
+    {
+        return $this->get('weekly', $query);
+    }
 }
-
-?>


### PR DESCRIPTION
I'd like to contribute to your project (e.g. add more documentation to the functions, improve error handling, provide specific classes as return values). But from my perspective this only can work well, when there are a coding standards defined. A widely adopted styleset is the [Symfony Coding Standards](http://symfony.com/doc/current/contributing/code/standards.html).

With this PR I want to propose to switch to _Symfony Coding Standards_ as coding standard.

The PR shall contain:
- [x] `phpcs` for checking the coding styles
- [x] `.travis.yml` for support for Travis CI
- [ ] Function documentation as expected by _Symfony Coding Standards_