### PR TITLE
Return full guzzle error response

### DIFF
--- a/src/TogglApi.php
+++ b/src/TogglApi.php
@@ -927,7 +927,7 @@ class TogglApi
         } catch (ClientException $e) {
             return (object) [
                 'success' => false,
-                'message' => $e->getMessage(),
+                'message' => $e->getResponse()->getBody()->getContents(),
             ];
         }
     }
@@ -950,7 +950,7 @@ class TogglApi
         } catch (ClientException $e) {
             return (object) [
                 'success' => false,
-                'message' => $e->getMessage(),
+                'message' => $e->getResponse()->getBody()->getContents(),
             ];
         }
     }
@@ -973,7 +973,7 @@ class TogglApi
         } catch (ClientException $e) {
             return (object) [
                 'success' => false,
-                'message' => $e->getMessage(),
+                'message' => $e->getResponse()->getBody()->getContents(),
             ];
         }
     }
@@ -996,7 +996,7 @@ class TogglApi
         } catch (ClientException $e) {
             return (object) [
                 'success' => false,
-                'message' => $e->getMessage(),
+                'message' => $e->getResponse()->getBody()->getContents(),
             ];
         }
     }


### PR DESCRIPTION
Guzzle returns truncated response when using `$e->getMessage()`:

```
stdClass Object
(
    [success] =>
    [message] => Client error: `GET https://www.toggl.com/api/v8/` resulted in a `400 Bad Request` response:
<!DOCTYPE html>
<html lang=en>
  <meta charset=utf-8>
  <meta name=viewport content="initial-scale=1, minimum-scale=1, w (truncated...)
)
```

`$e->getResponse()->getBody()->getContents()` returns full response body.