### PR TITLE
Fix/phpdoc types

### DIFF
--- a/src/TogglReportsApi.php
+++ b/src/TogglReportsApi.php
@@ -54,7 +54,7 @@ class TogglReportsApi
      *
      * @return bool|mixed|object
      */
-    public function getProjectReport($query)
+    public function getProjectReport(array $query)
     {
         return $this->get('project', $query);
     }
@@ -66,7 +66,7 @@ class TogglReportsApi
      *
      * @return bool|mixed|object
      */
-    public function getSummaryReport($query)
+    public function getSummaryReport(array $query)
     {
         return $this->get('summary', $query);
     }
@@ -78,7 +78,7 @@ class TogglReportsApi
      *
      * @return bool|mixed|object
      */
-    public function getDetailsReport($query)
+    public function getDetailsReport(array $query)
     {
         return $this->get('details', $query);
     }
@@ -90,7 +90,7 @@ class TogglReportsApi
      *
      * @return bool|mixed|object
      */
-    public function getWeeklyReport($query)
+    public function getWeeklyReport(array $query)
     {
         return $this->get('weekly', $query);
     }

--- a/src/TogglReportsApi.php
+++ b/src/TogglReportsApi.php
@@ -50,7 +50,7 @@ class TogglReportsApi
     /**
      * Get project report.
      *
-     * @param string $query
+     * @param array $query
      *
      * @return bool|mixed|object
      */
@@ -62,7 +62,7 @@ class TogglReportsApi
     /**
      * Get summary report.
      *
-     * @param string $query
+     * @param array $query
      *
      * @return bool|mixed|object
      */
@@ -74,7 +74,7 @@ class TogglReportsApi
     /**
      * Get details report.
      *
-     * @param string $query
+     * @param array $query
      *
      * @return bool|mixed|object
      */
@@ -86,7 +86,7 @@ class TogglReportsApi
     /**
      * Get weekly report.
      *
-     * @param string $query
+     * @param array $query
      *
      * @return bool|mixed|object
      */
@@ -103,7 +103,7 @@ class TogglReportsApi
      *
      * @return bool|mixed|object
      */
-    private function GET($endpoint, $query = array())
+    private function GET($endpoint, array $query = array())
     {
         try {
             $response = $this->client->get($endpoint, ['query' => $query]);


### PR DESCRIPTION
My IDE (PhpStorm) was nagging about incompatible parameters for the report requests (getSummaryReport, etc) as they were declared string in the phpDoc instead of array which they actually are. 

This PR fixes the phpDoc blocks for these functions and also adds parameter hinting in the method definition.