### PR TITLE
Update guzzlehttp/guzzle minimum requirement

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
         }
     },
     "require": {
-        "guzzlehttp/guzzle": "^6.0"
+        "guzzlehttp/guzzle": "^6.3"
     },
 	"require-dev": {
 		"squizlabs/php_codesniffer": "2.*",


### PR DESCRIPTION
Hello!

Great package, thanks! Having an issue though when using `composer update --prefer-lowest`. Guzzlehttp (curl) breaks if the authentication with Toggl doesn't work. Updating to a minimum of 6.3 makes the stars shine again.