### PR TITLE
Work with Guzzle 7.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
         }
     },
     "require": {
-        "guzzlehttp/guzzle": "^6.3"
+        "guzzlehttp/guzzle": "^7.0"
     },
 	"require-dev": {
 		"squizlabs/php_codesniffer": "2.*",

--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
         }
     },
     "require": {
-        "guzzlehttp/guzzle": "^7.0"
+        "guzzlehttp/guzzle": "^6.3|^7.0"
     },
 	"require-dev": {
 		"squizlabs/php_codesniffer": "2.*",


### PR DESCRIPTION
Guzzle 7.0 is required for later versions of Laravel, giving this the option of Guzzle 6.3 or 7.0 allows it to work with Laravel 8. I've used this implementation without issues