### PR TITLE
feat: add get paginated projects for TogglTrackMeApi

### DIFF
--- a/src/TogglTrackMeApi.php
+++ b/src/TogglTrackMeApi.php
@@ -180,6 +180,16 @@ class TogglTrackMeApi extends BaseApiClass
     }
 
     /**
+     * Get paginated projects for the current user.
+     *
+     * @return bool|mixed|object
+     */
+    public function getPaginatedProjects(int $startProjectId = 0)
+    {
+        return $this->GET('projects/paginated', ['start_project_id' => $startProjectId]);
+    }
+
+    /**
      * Get tags for the current user.
      *
      * @return bool|mixed|object


### PR DESCRIPTION
Get [paginated projects](https://developers.track.toggl.com/docs/projects#:~:text=The%20full%20list%20can%20be%20paginated%20by%20adding%20/paginated%20to%20the%20endpoint.%20The%20request%20can%20also%20include%20start_project_id%20as%20the%20query%20parameter%20in%20order%20to%20provide%20an%20offset.) of user