### PR TITLE
Fix v9 time entry tagging

### DIFF
--- a/src/TogglApi.php
+++ b/src/TogglApi.php
@@ -846,11 +846,18 @@ class TogglApi extends BaseApiClass
      * @param array $timeEntryIds
      * @param array $entry
      *
+     * API now only supports adding tags to one entry at the time
+     * Make one PUT for each time entry id
+     *
      * @return bool|mixed|object
      */
     public function updateTagsForTimeEntries($timeEntryIds, $entry)
     {
-        return $this->PUT('time_entries/'.implode(',', $timeEntryIds), ['time_entry' => $entry]);
+        $result = [];
+        foreach($timeEntryIds as $tid) {
+            $result[$tid] = $this->PUT('time_entries/'.$tid, $entry);
+        }
+        return $result;
     }
 
     /**


### PR DESCRIPTION
Updated the updateTagsForTimeEntries method to work with v9, where it is only possible to update tags for one time entry at the time.

Simply making one request per time entry allows method to work with existing parameters.
Returning array of responses.

I hope this can be useful.